### PR TITLE
Add explanation on how to run on codeanywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,17 @@ In alphabetical order:
 - Adis Bock
 - Lucas Price
 - Zach Gibson
+
+# CodeAnywhere
+
+If you develop using the [CodeAnywhere](https://codeanywhere.com/)
+platform, please note that the "**Run Project**" button will serve a
+list of files instead of the game. The game itself was moved from
+`index.html` to `game.html`. Just click on the file `game.html` and
+the game should start.
+
+## More details
+
+This change was introduced with commit
+[4107049a6ea0ce925b2e28b5087470ea0b4658dd](https://github.com/video-game-coding-club/geometry-smash/commit/4107049a6ea0ce925b2e28b5087470ea0b4658dd)
+and the introduction of using GitHub Pages to build our website.


### PR DESCRIPTION
Running the site on codeanywhere appears broken now that we split the
main page into an introduction and the actual game (in
`game.html`). This change adds instructions on how to play the game
Now after this change.