### PR TITLE
Update README with GitPod

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,19 @@ Please see also:
 - You might also want to check out our
   [wiki](https://github.com/video-game-coding-club/geometry-smash/wiki)
   with some useful information on how to contribute.
-- Or you can use
+- If you don't want to install any software and start developing
+  anyway have a look at
   [GitPod](https://gitpod.io#https://github.com/video-game-coding-club/geometry-smash)
-  as your fully featured IDE (the free plan is limited currently to 10
-  hours of usage per month).
+  as your fully featured IDE (Note that the free plan is limited
+  currently to 10 hours of usage per month).
+
+# GitPod
+
+[GitPod](https://gitpod.io#https://github.com/video-game-coding-club/geometry-smash)
+offers tight GitHub integration. All necessary `git` commands can be
+run via the GUI instead of the command line. The game itself lives in
+`game.html`. Just right-click on the file `game.html` and open it with
+the "Mini Browser" and the game should start.
 
 # Online JavaScript Editor
 
@@ -63,18 +72,10 @@ list of files instead of the game. The game itself was moved from
 `index.html` to `game.html`. Just click on the file `game.html` and
 the game should start.
 
-## More details
+# More details on where the game lives
 
 The game script was loaded in `index.html` but recently we introduced
 a landing page and split the game code into a separate page,
 `game.html`.  This change was introduced with commit
 [4107049a6ea0ce925b2e28b5087470ea0b4658dd](https://github.com/video-game-coding-club/geometry-smash/commit/4107049a6ea0ce925b2e28b5087470ea0b4658dd)
 and the introduction of using GitHub Pages to build our website.
-
-# GitPod
-
-An alternative to using the [CodeAnywhere](https://codeanywhere.com/)
-platform,
-[GitPod](https://gitpod.io#https://github.com/video-game-coding-club/geometry-smash)
-offers tighter GitHub integration. All necessary `git` commands can be
-run via the GUI instead of the command line.


### PR DESCRIPTION
Since we are running into firewall issues at the school with
the CodeAnywhwere platform, we started using GitPod instead. And it
turns out to be much easier to use! This change updates the README to
put GitPod first in the list of development platforms.