### PR TITLE
Change the mouse event

### DIFF
--- a/main.js
+++ b/main.js
@@ -435,7 +435,12 @@ let mouseClickedListeners = [
 
 (function() {
   let initialize = function() {
-    canvas.addEventListener('click', mouseClick);
+    /* The mousedown event is fired when a pointing device button is
+       pressed on an element [1].
+
+       [1] https://developer.mozilla.org/en-US/docs/Web/Events/mousedown
+    */
+    canvas.addEventListener('mousedown', mouseClick);
   };
 
   let mouseClick = function(event) {


### PR DESCRIPTION
The 'click' even is fired when the mouse is pressed _and_
released. The 'mousedown' event is fired when the mouse button is
pressed. This should lead to a more intuitive hero behavior.