### PR TITLE
Fix some collision stuff

### DIFF
--- a/main.js
+++ b/main.js
@@ -436,7 +436,7 @@ var drawObstacles = function() {
       let obs_top = obs_y + obstacles[i][0].h;
       drawBoundingBox(obstacles[i][0], obs_x, obs_y);
       if (hero.x + hero.w > obs_left &&
-          hero.y > obs_top) {
+        hero.y > obs_top) {
         drawGameOverSign();
       }
     } else {

--- a/main.js
+++ b/main.js
@@ -321,7 +321,7 @@ var obstacleExplodingWall = {
   x: 0,
   y: 0,
   w: 10,
-  h: -100
+  h: -canvas.height
 };
 
 let drawGameOverSign = function() {
@@ -432,9 +432,11 @@ var drawObstacles = function() {
     let obs_y = floorHeight;
     if (obs_x - rightside > 0 && obs_x < canvas.width) {
       obstacles[i][0].draw(obs_x, obs_y);
+      let obs_left = obs_x + obstacles[i][0].x;
+      let obs_top = obs_y + obstacles[i][0].h;
       drawBoundingBox(obstacles[i][0], obs_x, obs_y);
-      if (hero.x + hero.w > obs_x &&
-        hero.y > obs_y + obstacles[i][0].h) {
+      if (hero.x + hero.w > obs_left &&
+          hero.y > obs_top) {
         drawGameOverSign();
       }
     } else {


### PR DESCRIPTION
Collision detection for some objects (e.g. saw) was incorrect because
we were not evaluating the actual left side. Added obs_left and obs_top
variables to make this clear/readible for teaching purposes.
But there's probably a better way to handle these variables.
(more OO'ish?)