### PR TITLE
Don't deploy gh-pages for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,13 +34,13 @@ script:
   - bundle exec jekyll build
   - npm test
 
-deploy:
-  provider: pages
-  skip-cleanup: true
-  github-token: $GITHUB_TOKEN
-  keep-history: true
-  on:
-    branch: master
+#deploy:
+#  provider: pages
+#  skip-cleanup: true
+#  github-token: $GITHUB_TOKEN
+#  keep-history: true
+#  on:
+#    branch: master
 
 after_success:
   - npm run coverage


### PR DESCRIPTION
Until we have a need to server the webpage out of a separate branch, let's disable the publisher.