### PR TITLE
Fix incorrect `baseurl`

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,9 +2,12 @@ theme: jekyll-theme-hacker
 title: Geometry Smash
 google_analytics: UA-123354485-1
 exclude:
+  - vendor
   - CODEOWNERS
   - Dangerfile
   - node_modules
+#baseurl: {{ site.baseurl }}
+baseurl: geometry-smash
 kramdown:
   auto_ids: true
 plugins:


### PR DESCRIPTION
The `baseurl` should point to the project name. It would be nice to
avoid hard-coding the name.