### PR TITLE
Keep original main.js file for debugging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,7 @@ jobs:
       script:
         - bundle exec jekyll build
         - babel main.js --out-file main-babel.js
+        - mv -v _site/main.js _site/main-original.js
         - cp -v main-babel.js _site/main.js
         - tree _site
 


### PR DESCRIPTION
It might help debugging if we keep the original JavaScript file in the
deployed webpage.